### PR TITLE
Added IE10 support.

### DIFF
--- a/src/main/resources/de/barop/gwt/PushState.gwt.xml
+++ b/src/main/resources/de/barop/gwt/PushState.gwt.xml
@@ -55,9 +55,6 @@
       <when-property-is
         name="user.agent"
         value="ie8" />
-      <when-property-is
-        name="user.agent"
-        value="ie9" />
     </any>
   </set-property>
 


### PR DESCRIPTION
Removed the predefined history.pushStateSupported for the ie9 permutation.
This is necessary since ie9 is also used for internet explorer 10, which
supports pushState and therefore leads to an exception in the generated
initialization code.
