### PR TITLE
Upgrade to GWT 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <groupId>de.barop.gwt</groupId>
   <artifactId>gwt-pushstate</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.6.0-SNAPSHOT</version>
   <name>GWT pushState</name>
   <description>gwt-pushstate implements easy to use HTML5 pushState support for GWT.</description>
   <url>https://github.com/jbarop/gwt-pushstate</url>
@@ -49,7 +49,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <gwt.version>2.5.1</gwt.version>
+    <gwt.version>2.6.0</gwt.version>
   </properties>
 
 


### PR DESCRIPTION
- Changes the GWT version to 2.6.0.
- Changes the library version to 2.6.0-SNAPSHOT in order to reflect the
  potential incompatibilities caused by this change.
