### PR TITLE
pass popstate event to oldhandler

### DIFF
--- a/src/main/java/de/barop/gwt/client/HistoryImplPushState.java
+++ b/src/main/java/de/barop/gwt/client/HistoryImplPushState.java
@@ -98,7 +98,7 @@ public class HistoryImplPushState extends HistoryImpl {
         that.@de.barop.gwt.client.HistoryImplPushState::onPopState(Ljava/lang/String;)(e.state.historyToken);
       }
       if (oldHandler) {
-        oldHandler();
+        oldHandler(e);
       }
     });
   }-*/;

--- a/src/test/java/de/barop/gwt/client/HistoryImplPushStateGwtTest.java
+++ b/src/test/java/de/barop/gwt/client/HistoryImplPushStateGwtTest.java
@@ -17,7 +17,6 @@ package de.barop.gwt.client;
 
 import static com.google.gwt.user.client.Window.Location.getQueryString;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Window;
 
@@ -37,7 +36,6 @@ public class HistoryImplPushStateGwtTest extends AbstractPushStateTest {
   }
 
   public void testInit() {
-    GWT.create(History.class);
     assertEquals(1, states.size());
     assertEquals(startPath, states.peek().url);
     // remove the query string with the codeserver

--- a/src/test/java/de/barop/gwt/client/HistoryImplPushStateGwtTest.java
+++ b/src/test/java/de/barop/gwt/client/HistoryImplPushStateGwtTest.java
@@ -36,7 +36,7 @@ public class HistoryImplPushStateGwtTest extends AbstractPushStateTest {
   }
 
   public void testInit() {
-    assertEquals(1, states.size());
+    assertEquals(statesOnTestStart, states.size());
     assertEquals(startPath, states.peek().url);
     // remove the query string with the codeserver
     String expectedHistoryToken = states.peek().url.substring(1).split("\\?")[0];


### PR DESCRIPTION
One character fix.  Passes the onpopstate event to any existing handlers.

The test case was failing because Gwt.Create(History.class) was being called twice.   Only one History handler would work before this patch, so creating two wasn't a problem until that was fixed.
